### PR TITLE
Update webhook validation for Coolify deployment URLs

### DIFF
--- a/.github/workflows/test-deployment-secrets.yml
+++ b/.github/workflows/test-deployment-secrets.yml
@@ -22,11 +22,11 @@ jobs:
             exit 1
           fi
           
-          # Validate URL format - check essential parts
-          if [[ "$COOLIFY_WEBHOOK" =~ ^https:// ]] && [[ "$COOLIFY_WEBHOOK" == *"/webhooks/"* ]] && [[ "$COOLIFY_WEBHOOK" == *"coolify"* ]]; then
+          # Validate URL format - check for Coolify deployment or webhook URLs
+          if [[ "$COOLIFY_WEBHOOK" =~ ^https:// ]] && [[ "$COOLIFY_WEBHOOK" == *"coolify"* ]] && ([[ "$COOLIFY_WEBHOOK" == *"/api/v1/deploy"* ]] || [[ "$COOLIFY_WEBHOOK" == *"/webhooks/"* ]]); then
             echo "✅ Webhook URL format is valid"
           else
-            echo "❌ Webhook URL format is invalid - should be HTTPS URL containing 'coolify' and '/webhooks/'"
+            echo "❌ Webhook URL format is invalid - should be HTTPS Coolify URL with '/api/v1/deploy' or '/webhooks/'"
             exit 1
           fi
           


### PR DESCRIPTION
## Summary
Update webhook URL validation to support actual Coolify deployment webhook format.

## Changes
- Support both `/api/v1/deploy` and `/webhooks/` URL formats
- Handle deployment webhooks with uuid parameter like: `https://app.coolify.io/api/v1/deploy?uuid=...`
- Maintain security validation while supporting real webhook URLs

## Background
The original validation only supported `/webhooks/` URLs, but actual Coolify deployment webhooks use `/api/v1/deploy` format with project-specific UUID parameters.

## Testing
With correct webhook URL now configured as secret, this should allow the deployment secrets test to pass.