### PR TITLE
Fix Coolify token validation for real token formats

### DIFF
--- a/.github/workflows/test-deployment-secrets.yml
+++ b/.github/workflows/test-deployment-secrets.yml
@@ -34,11 +34,11 @@ jobs:
           if [ -n "$COOLIFY_TOKEN" ]; then
             # Check minimum length without revealing actual length
             if [ ${#COOLIFY_TOKEN} -ge 10 ]; then
-              # Check it contains only alphanumeric characters and safe symbols
-              if [[ "$COOLIFY_TOKEN" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+              # Basic token validation - just ensure it looks like a token (no spaces, reasonable characters)
+              if [[ "$COOLIFY_TOKEN" =~ ^[^[:space:]]+$ ]] && [[ ${#COOLIFY_TOKEN} -le 200 ]]; then
                 echo "✅ Coolify token format is valid"
               else
-                echo "❌ Coolify token contains invalid characters"
+                echo "❌ Coolify token format is invalid (contains spaces or too long)"
                 exit 1
               fi
             else


### PR DESCRIPTION
## Summary
Fix token validation to work with actual Coolify API token formats.

## Problem
The previous validation used `^[a-zA-Z0-9_-]+$` regex which was too restrictive and failed on real Coolify tokens that contain other valid characters.

## Solution  
- Replace character-set validation with practical checks
- Validate no spaces (tokens shouldn't contain spaces)
- Check reasonable length bounds (10-200 characters)
- Allow any other characters to accommodate various token formats

## Testing
This should allow the deployment secrets test to pass with real Coolify tokens.