### PR TITLE
Fix uv workspace support in Dockerfile

### DIFF
--- a/services/ingestion/Dockerfile
+++ b/services/ingestion/Dockerfile
@@ -10,8 +10,9 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv for fast Python package management
-RUN pip install uv
+# Install uv for fast Python package management (latest version with workspace support)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.cargo/bin:$PATH"
 
 # Set working directory to repository root for monorepo access
 WORKDIR /app


### PR DESCRIPTION
## Summary
- Fix critical deployment error where uv doesn't support --workspace flag
- Use official uv installer to get latest version with workspace support
- Ensure proper PATH configuration for uv command availability

## Problem
Coolify deployment was failing with:
```
error: unexpected argument '--workspace' found
```

## Solution  
- Replace `pip install uv` with official installer
- Add uv to PATH via `/root/.cargo/bin:$PATH`
- This gets us the latest uv version that supports workspace operations

## Test plan
- [ ] Verify Coolify deployment succeeds with workspace dependencies
- [ ] Confirm shared libraries from libs/common are accessible
- [ ] Validate FastAPI application starts correctly