### PR TITLE
Fix uv installation path from .local/bin to /usr/local/bin

### DIFF
--- a/services/ingestion/Dockerfile
+++ b/services/ingestion/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install uv for fast Python package management (latest version with workspace support)
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    mv ~/.cargo/bin/uv /usr/local/bin/uv
+    mv ~/.local/bin/uv /usr/local/bin/uv
 
 # Set working directory to repository root for monorepo access
 WORKDIR /app


### PR DESCRIPTION
- Correct path from ~/.cargo/bin to ~/.local/bin based on installer output
- uv installer actually installs to /root/.local/bin not /root/.cargo/bin
- This resolves the 'cannot stat' error during Docker build

Based on actual installer output showing 'installing to /root/.local/bin'