### PR TITLE
Fix uv workspace sync to use --all-packages instead of --workspace

### DIFF
--- a/services/ingestion/Dockerfile
+++ b/services/ingestion/Dockerfile
@@ -25,7 +25,7 @@ COPY libs/ libs/
 COPY services/ingestion/ services/ingestion/
 
 # Install all workspace dependencies including shared libraries
-RUN uv sync --frozen --no-dev --workspace
+RUN uv sync --frozen --no-dev --all-packages
 
 # Production stage - Minimal runtime image
 FROM python:3.11-slim AS runtime


### PR DESCRIPTION
- Replace deprecated --workspace flag with --all-packages
- --all-packages is the correct flag for syncing all workspace members
- This resolves the 'unexpected argument --workspace' error

Based on uv sync --help showing --all-packages for workspace package sync