### PR TITLE
Update lock file to include psutil dependency

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -410,10 +410,14 @@ version = "0.1.0"
 source = { virtual = "services/ingestion" }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "psutil" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" }]
+requires-dist = [
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.116.1" },
+    { name = "psutil", specifier = ">=6.1.0" },
+]
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
The previous deployment failed because psutil dependency was missing from uv.lock. This update ensures psutil>=6.1.0 is properly installed during container build.